### PR TITLE
style(flake.nix): Append treefmt-nix into inputs on flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,7 +57,8 @@
         "flake-parts": "flake-parts",
         "libxcb-errors": "libxcb-errors",
         "nixpkgs": "nixpkgs",
-        "systems": "systems"
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "systems": {
@@ -72,6 +73,26 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default-linux",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,10 @@
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     libxcb-errors = {
       url = "github:SimulaVR/libxcb-errors";
       flake = false;
@@ -16,8 +20,10 @@
     inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = import inputs.systems;
+      imports = [ inputs.treefmt-nix.flakeModule ];
 
-      perSystem = { pkgs, lib, ... }:
+      perSystem =
+        { pkgs, lib, ... }:
         let
           libxcb-errors = pkgs.stdenv.mkDerivation {
             name = "libxcb-errors";
@@ -134,6 +140,13 @@
             default = wlroots;
           };
 
+          treefmt = {
+            projectRootFile = ".git/config";
+
+            # Nix
+            programs.nixfmt.enable = true;
+          };
+
           devShells.default = pkgs.mkShell rec {
             nativeBuildInputs = [
               pkgs.nil
@@ -162,9 +175,9 @@
               pkgs.xorg.libX11.dev
               pkgs.xorg.libxcb.dev
               pkgs.xorg.xinput
-              # pkgs.mesa              # <- exclude when bumping to newer nixpkgs
-              pkgs.libdrm          # <- include when bumping to newer nixpkgs
-              pkgs.libgbm          # <- include when bumping to newer nixpkgs
+              # pkgs.mesa # <- exclude when bumping to newer nixpkgs
+              pkgs.libdrm # <- include when bumping to newer nixpkgs
+              pkgs.libgbm # <- include when bumping to newer nixpkgs
               pkgs.mesa-gl-headers # <- include when bumping to newer nixpkgs
 
               libxcb-errors


### PR DESCRIPTION
# Purpose

- To align code formatters on this repo (This PR uses [nixfmt](https://github.com/NixOS/nixfmt)).