### PR TITLE
build(flakes): Update nixpkgs from `nixos-25.11` to `nixpkgs-unstable`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,34 +20,18 @@
         "type": "github"
       }
     },
-    "libxcb-errors": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1732504353,
-        "narHash": "sha256-LPNRkLQSTPkCRIc9lhHYIvQs8ags3GpGehCWLY5qvJw=",
-        "owner": "SimulaVR",
-        "repo": "libxcb-errors",
-        "rev": "cb26a7dc442b0bb37f8648986350291d3d45a47a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "SimulaVR",
-        "repo": "libxcb-errors",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770464364,
-        "narHash": "sha256-z5NJPSBwsLf/OfD8WTmh79tlSU8XgIbwmk6qB1/TFzY=",
+        "lastModified": 1771207753,
+        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "23d72dabcb3b12469f57b37170fcbc1789bd7457",
+        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -55,7 +39,6 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "libxcb-errors": "libxcb-errors",
         "nixpkgs": "nixpkgs",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default-linux";
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
@@ -9,10 +9,6 @@
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
-    };
-    libxcb-errors = {
-      url = "github:SimulaVR/libxcb-errors";
-      flake = false;
     };
   };
 
@@ -25,32 +21,6 @@
       perSystem =
         { pkgs, lib, ... }:
         let
-          libxcb-errors = pkgs.stdenv.mkDerivation {
-            name = "libxcb-errors";
-            src = inputs.libxcb-errors;
-
-            nativeBuildInputs = [
-              pkgs.pkg-config
-              pkgs.python3
-              pkgs.autoreconfHook
-            ];
-
-            buildInputs = [
-              pkgs.xorg.libxcb
-              pkgs.xorg.libXau
-              pkgs.xorg.libXdmcp
-              pkgs.xorg.utilmacros
-              pkgs.xorg.xcbproto
-              pkgs.libbsd
-            ];
-
-            meta = {
-              description = "Allow XCB errors to print less opaquely";
-              homepage = "https://github.com/SimulaVR/libxcb-errors";
-              license = lib.licenses.mit;
-              platforms = lib.platforms.linux;
-            };
-          };
           wlroots = pkgs.stdenv.mkDerivation {
             pname = "wlroots";
             version = "0.10.0";
@@ -78,20 +48,19 @@
               pkgs.libinput
               pkgs.libxkbcommon
               pkgs.pixman
-              pkgs.xorg.xcbutilwm
+              pkgs.xcbutilwm
               pkgs.libcap
-              pkgs.xorg.xcbutilimage
-              pkgs.xorg.xcbutilerrors
+              pkgs.xcbutilimage
+              pkgs.xcbutilerrors
               pkgs.libpng
               pkgs.ffmpeg_4
-              pkgs.xorg.libX11.dev
-              pkgs.xorg.libxcb.dev
-              pkgs.xorg.xinput
+              pkgs.libX11.dev
+              pkgs.libxcb.dev
+              pkgs.xinput
               pkgs.libdrm
               pkgs.libgbm
               pkgs.mesa-gl-headers
-
-              libxcb-errors
+              pkgs.libxcb-errors
             ];
 
             mesonFlags = [
@@ -166,21 +135,20 @@
               pkgs.libinput
               pkgs.libxkbcommon
               pkgs.pixman
-              pkgs.xorg.xcbutilwm
+              pkgs.xcbutilwm
               pkgs.libcap
-              pkgs.xorg.xcbutilimage
-              pkgs.xorg.xcbutilerrors
+              pkgs.xcbutilimage
+              pkgs.xcbutilerrors
               pkgs.libpng
               pkgs.ffmpeg_4
-              pkgs.xorg.libX11.dev
-              pkgs.xorg.libxcb.dev
-              pkgs.xorg.xinput
+              pkgs.libX11.dev
+              pkgs.libxcb.dev
+              pkgs.xinput
               # pkgs.mesa # <- exclude when bumping to newer nixpkgs
               pkgs.libdrm # <- include when bumping to newer nixpkgs
               pkgs.libgbm # <- include when bumping to newer nixpkgs
               pkgs.mesa-gl-headers # <- include when bumping to newer nixpkgs
-
-              libxcb-errors
+              pkgs.libxcb-errors
             ];
 
             LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;

--- a/flake.nix
+++ b/flake.nix
@@ -33,35 +33,8 @@
               "examples"
             ];
 
-            nativeBuildInputs = [
-              pkgs.meson
-              pkgs.cmake
-              pkgs.ninja
-              pkgs.pkg-config
-              pkgs.wayland-scanner
-            ];
-
-            buildInputs = [
-              pkgs.wayland
-              pkgs.libGL
-              pkgs.wayland-protocols
-              pkgs.libinput
-              pkgs.libxkbcommon
-              pkgs.pixman
-              pkgs.xcbutilwm
-              pkgs.libcap
-              pkgs.xcbutilimage
-              pkgs.xcbutilerrors
-              pkgs.libpng
-              pkgs.ffmpeg_4
-              pkgs.libX11.dev
-              pkgs.libxcb.dev
-              pkgs.xinput
-              pkgs.libdrm
-              pkgs.libgbm
-              pkgs.mesa-gl-headers
-              pkgs.libxcb-errors
-            ];
+            nativeBuildInputs = tools.dependencies;
+            inherit buildInputs LDFLAGS;
 
             mesonFlags = [
               "-Dlibcap=enabled"
@@ -70,11 +43,6 @@
               "-Dx11-backend=enabled"
               "-Dxcb-icccm=disabled"
               "-Dxcb-errors=enabled"
-            ];
-
-            LDFLAGS = [
-              "-lX11-xcb"
-              "-lxcb-xinput"
             ];
 
             postInstall = ''
@@ -102,6 +70,47 @@
               platforms = lib.platforms.linux;
             };
           };
+
+          tools.development = [
+            # LSP
+            pkgs.nil # Nix
+
+            # Command Runner
+            pkgs.just
+          ];
+          tools.dependencies = [
+            pkgs.meson
+            pkgs.cmake
+            pkgs.ninja
+            pkgs.pkg-config
+            pkgs.wayland-scanner
+          ];
+          buildInputs = [
+            pkgs.wayland
+            pkgs.libGL
+            pkgs.wayland-protocols
+            pkgs.libinput
+            pkgs.libxkbcommon
+            pkgs.pixman
+            pkgs.xcbutilwm
+            pkgs.libcap
+            pkgs.xcbutilimage
+            pkgs.xcbutilerrors
+            pkgs.libpng
+            pkgs.ffmpeg_4
+            pkgs.libX11.dev
+            pkgs.libxcb.dev
+            pkgs.xinput
+            # pkgs.mesa # <- exclude when bumping to newer nixpkgs
+            pkgs.libdrm # <- include when bumping to newer nixpkgs
+            pkgs.libgbm # <- include when bumping to newer nixpkgs
+            pkgs.mesa-gl-headers # <- include when bumping to newer nixpkgs
+            pkgs.libxcb-errors
+          ];
+          LDFLAGS = [
+            "-lX11-xcb"
+            "-lxcb-xinput"
+          ];
         in
         {
           packages = {
@@ -116,47 +125,9 @@
             programs.nixfmt.enable = true;
           };
 
-          devShells.default = pkgs.mkShell rec {
-            nativeBuildInputs = [
-              pkgs.nil
-              pkgs.just
-
-              pkgs.meson
-              pkgs.cmake
-              pkgs.ninja
-              pkgs.pkg-config
-              pkgs.wayland-scanner
-            ];
-
-            buildInputs = [
-              pkgs.wayland
-              pkgs.libGL
-              pkgs.wayland-protocols
-              pkgs.libinput
-              pkgs.libxkbcommon
-              pkgs.pixman
-              pkgs.xcbutilwm
-              pkgs.libcap
-              pkgs.xcbutilimage
-              pkgs.xcbutilerrors
-              pkgs.libpng
-              pkgs.ffmpeg_4
-              pkgs.libX11.dev
-              pkgs.libxcb.dev
-              pkgs.xinput
-              # pkgs.mesa # <- exclude when bumping to newer nixpkgs
-              pkgs.libdrm # <- include when bumping to newer nixpkgs
-              pkgs.libgbm # <- include when bumping to newer nixpkgs
-              pkgs.mesa-gl-headers # <- include when bumping to newer nixpkgs
-              pkgs.libxcb-errors
-            ];
-
-            LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
-
-            LDFLAGS = [
-              "-lX11-xcb"
-              "-lxcb-xinput"
-            ];
+          devShells.default = pkgs.mkShell {
+            nativeBuildInputs = tools.dependencies ++ tools.development;
+            inherit buildInputs LDFLAGS;
           };
         };
     };


### PR DESCRIPTION
## Purposes

- To update buildInputs & nativeBuildInputs from hard-coding to some variables.
- To use `nixpkgs-unstable` instead of `nixos-25.11`.

## Why I create this PR to update to `nixpkgs-unstable`

That's because we don't have any reasons to use versioned nixpkgs (I might miss other reasons so it's not 100% accurate). I suggest a pattern for `flake.nix`, to use other flake's outputs. The following code block is it.

```nix
{
  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
  inputs.wlroots.url = "github:SimulaVR/wlroots"; # The input, wlroots already has `nixpkgs-unstable`, so it doesn't depend this example's nixpkgs input.

  outputs =
  # ... 
}
```

There are two reasons for adopting this PR (the first one is the above one). Now nixpkgs-unstable branch has `pkgs.libxcb-errors` attribute, so we can reduce the dependency, [github.com/SimulaVR/libxcb-errors](https://github.com/SimulaVR/libxcb-errors).

...If we use [github.com/SimulaVR/libxcb-errors](https://github.com/SimulaVR/libxcb-errors) still, to update our custom libxcb-errors, of cource we cannot delete our libxcb-errors' repo.