### PR TITLE
Delete git submodules because of unused SimulaVR/libxcb-errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libxcb-errors"]
-	path = libxcb-errors
-	url = https://github.com/SimulaVR/libxcb-errors.git


### PR DESCRIPTION
# Purposes

- To delete git submodules because we don't need to use [SimulaVR/libxcb-errors](https://github.com/SimulaVR/libxcb-errors).